### PR TITLE
fix: preserve time spacing and completion recency

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marucs-anime",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "Marucs",
   "displayName": "Marucs' Anime",
   "description": "Anime watch-history language support and editing tools for VS Code",

--- a/apps/vscode-extension/src/commands/date-time-plans.ts
+++ b/apps/vscode-extension/src/commands/date-time-plans.ts
@@ -17,7 +17,12 @@ export const planTimeInsertion = (
     return { reason: 'unsupported-line', tag: 'no-change' }
   }
 
-  const text = empty ? `${input.time} - ` : startOnly ? ` - ${input.time} ` : ` ${input.time} `
+  const separator = /\s$/u.test(input.lineText) ? '' : ' '
+  const text = empty
+    ? `${input.time} - `
+    : startOnly
+      ? ` - ${input.time} `
+      : `${separator}${input.time} `
   const warning =
     input.currentDocumentDate === input.today
       ? undefined

--- a/apps/vscode-extension/src/completion/local-completion.ts
+++ b/apps/vscode-extension/src/completion/local-completion.ts
@@ -14,6 +14,8 @@ export type LocalCompletion = Readonly<{
   replaceFrom: number
 }>
 
+export const completionSortText = (index: number): string => String(index).padStart(8, '0')
+
 type CompletionContext = Readonly<{
   kind: CompletionKind
   prefix: string

--- a/apps/vscode-extension/src/completion/register-local-completion.ts
+++ b/apps/vscode-extension/src/completion/register-local-completion.ts
@@ -3,7 +3,7 @@ import { CompletionItem, CompletionItemKind, languages, Range } from 'vscode'
 import type { Disposable } from '../activation/create-extension-app.js'
 import type { AnimeCatalog } from '../catalog/anime-catalog.js'
 import type { DocumentController } from '../documents/document-controller.js'
-import { localCompletionsAt, showQueryAt } from './local-completion.js'
+import { completionSortText, localCompletionsAt, showQueryAt } from './local-completion.js'
 
 const LANGUAGE_ID = 'anime-list'
 
@@ -49,9 +49,10 @@ export const registerLocalCompletion = (
                 }))
             : []),
         ]
-        return combined.map((value) => {
+        return combined.map((value, index) => {
           const item = new CompletionItem(value.label, itemKind(value.kind))
           item.insertText = value.insertText
+          item.sortText = completionSortText(index)
           item.range = new Range(
             position.line,
             value.replaceFrom,

--- a/apps/vscode-extension/test/commands/date-time-plans.test.ts
+++ b/apps/vscode-extension/test/commands/date-time-plans.test.ts
@@ -21,6 +21,9 @@ describe('time insertion plan', () => {
     expect(
       planTimeInsertion({ lineText: '07:05 -', time: '07:30', today: '02/07/2026' }),
     ).toMatchObject({ tag: 'insert', text: ' 07:30 ' })
+    expect(
+      planTimeInsertion({ lineText: '07:05 - ', time: '07:30', today: '02/07/2026' }),
+    ).toMatchObject({ tag: 'insert', text: '07:30 ' })
   })
 
   it('warns when the document date is different or absent', () => {

--- a/apps/vscode-extension/test/completion/local-completion.test.ts
+++ b/apps/vscode-extension/test/completion/local-completion.test.ts
@@ -1,7 +1,11 @@
 import { parseAnlDocument } from '@marucs-anime/core'
 import { describe, expect, it } from 'vitest'
 
-import { localCompletionsAt, showQueryAt } from '../../src/completion/local-completion.js'
+import {
+  completionSortText,
+  localCompletionsAt,
+  showQueryAt,
+} from '../../src/completion/local-completion.js'
 
 const document = parseAnlDocument(`01/04/2022
 Older Show:
@@ -23,6 +27,10 @@ describe('local completion', () => {
         replaceFrom: 0,
       },
     ])
+  })
+
+  it('provides lexical sort keys that preserve recency order in VS Code', () => {
+    expect([0, 1, 12].map(completionSortText)).toEqual(['00000000', '00000001', '00000012'])
   })
 
   it('completes people inside company braces', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marucs-anime-monorepo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.12.1",


### PR DESCRIPTION
## Summary

- avoid adding a second space when the time shortcut completes a start entry
- preserve local completion recency through explicit VS Code sort keys
- bump the extension bugfix version to 0.5.1

## Regression coverage

- second time insertion after `HH:MM - ` inserts only `HH:MM `
- completion sort keys preserve the existing latest-mention-first order

## Validation

- `pnpm check`
- `pnpm test:coverage`
- `pnpm package`
- `pnpm package:verify`
- installed `marucs.marucs-anime@0.5.1` in the default VS Code profile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date and time insertion to preserve existing spacing, including entries with trailing spaces.
  - Updated completion ordering to provide more consistent, predictable results.

- **Tests**
  - Added coverage for spacing behavior during date/time insertion.
  - Added validation for completion ordering across numeric positions.

- **Release**
  - Updated the extension and package version to 0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->